### PR TITLE
fix level 11 code indentation

### DIFF
--- a/src/app/exercises/merge/merge-exercise.ts
+++ b/src/app/exercises/merge/merge-exercise.ts
@@ -6,13 +6,15 @@ export class MergeExercise implements Exercise {
         'banana', 'old-banana', 'old-banana', 'banana', 'banana'
     ];
     readonly expectedFruits = ['apple', 'apple', 'apple', 'banana', 'banana', 'banana'];
-    readonly code = `const apples = from(["apple",
+    readonly code = `const apples = from([
+    "apple",
     "apple",
     "old-apple",
     "apple",
     "old-apple"]);
 
-const bananas = from(["banana",
+const bananas = from([
+    "banana",
     "old-banana",
     "old-banana",
     "banana",


### PR DESCRIPTION
When I first tried level 11, I didn't notice the first `"apple"` or `"orange"` because of the indentation.